### PR TITLE
Revert change log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ AGC library change log
 7.0.2
 -----
 
-  * CHANGED: pin python and python module versions
+  * ADDED: DELETE-ME - Version bump placeholder for develop branch
 
 7.0.1
 -----


### PR DESCRIPTION
Manually revert the Change Log entry to keep the builds of sw_xvf3510 working.