### PR TITLE
Fix copyright dates

### DIFF
--- a/lib_agc/src/agc_control.xc
+++ b/lib_agc/src/agc_control.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, XMOS Ltd, All rights reserved
+// Copyright (c) 2017-2021, XMOS Ltd, All rights reserved
 #include "agc_control.h"
 
 void agc_command_handler(chanend c_command, agc_state_t &agc_state){

--- a/tests/agc_unit_tests/src/agc_unit_tests.h
+++ b/tests/agc_unit_tests/src/agc_unit_tests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, XMOS Ltd, All rights reserved
+// Copyright (c) 2018-2021, XMOS Ltd, All rights reserved
 #ifndef AGC_UNIT_TESTS_H_
 #define AGC_UNIT_TESTS_H_
 


### PR DESCRIPTION
I must have used the wrong dates when I was updating the files after the review comments. The source check didn't detect the error, but it failed on developed after I merged https://github.com/xmos/lib_agc/pull/130.