### PR TITLE
Re-apply original copyright dates

### DIFF
--- a/lib_agc/api/agc_control_map.h
+++ b/lib_agc/api/agc_control_map.h
@@ -1,4 +1,4 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2020-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef AGC_CONTROL_MAP_H_
 #define AGC_CONTROL_MAP_H_

--- a/lib_agc/src/agc_control.xc
+++ b/lib_agc/src/agc_control.xc
@@ -1,4 +1,4 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "agc_control.h"
 

--- a/lib_agc/src/agc_control_map.xc
+++ b/lib_agc/src/agc_control_map.xc
@@ -1,4 +1,4 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2020-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "agc_conf.h"
 #include "agc_control_map.h"

--- a/tests/agc_unit_tests/generate_unity_runners.py
+++ b/tests/agc_unit_tests/generate_unity_runners.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2020-2021, XMOS Ltd, All rights reserved
-# This software is available under the terms provided in LICENSE.txt.
+# Copyright 2020-2021 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import glob
 import os.path
 import subprocess

--- a/tests/agc_unit_tests/src/agc_conf.h
+++ b/tests/agc_unit_tests/src/agc_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef AGC_CONF_H_

--- a/tests/agc_unit_tests/src/test_agc.xc
+++ b/tests/agc_unit_tests/src/test_agc.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "agc_unit_tests.h"
 

--- a/tests/test_wav_agc/src/agc_conf.h
+++ b/tests/test_wav_agc/src/agc_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef AGC_CONF_H_

--- a/tests/test_wav_agc/src/test_wav_agc.xc
+++ b/tests/test_wav_agc/src/test_wav_agc.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include<platform.h>
 


### PR DESCRIPTION
Now that the source checker bug is fixed in infr_apps, the original copyright dates can be maintained.