### PR TITLE
modify config file to enable loss control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 AGC library change log
 ======================
 
+8.2.1
+-----
+
+  * FIXED: lc_enabled on chan 1 changed in config file to match lib_audio_pipelines
+
 8.2.0
 -----
 

--- a/lib_agc/config/agc_2ch.json
+++ b/lib_agc/config/agc_2ch.json
@@ -39,7 +39,7 @@
                 "init_gain": 500,
                 "upper_threshold": 0.4,
                 "lower_threshold": 0.4,
-                "lc_enabled": 0,
+                "lc_enabled": 1,
                 "lc_n_frame_near": 34,
                 "lc_n_frame_far": 17,
                 "lc_corr_threshold": 0.993,

--- a/lib_agc/module_build_info
+++ b/lib_agc/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 8.2.0
+VERSION = 8.2.1
 
 DEPENDENT_MODULES = lib_dsp(>=6.0.1) \
                     lib_voice_toolbox(>=8.0.0) \


### PR DESCRIPTION
modify config file so that loss control is enabled on the comms channel - this is to match the behaviour in lib_audio_pipelines.

note this is a redo of PR153 but incorporating comments from @lucianomartin - that old PR was based on a now defunct branch so i made a new one..