### PR TITLE
Update versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.18.0') _
+@Library('xmos_jenkins_shared_library@v0.20.0') _
 
 getApproval()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 flake8==3.8.3
+
+# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
+importlib-metadata==4.13.0
 matplotlib==3.3.1
 
 # Pin numpy to 1.18.5 due to tensorflow v2.1.1 hard pinning it to that version.


### PR DESCRIPTION
Update the XMOS Jenkins Shared Library version to v0.20.0.  Pin the version of the Python package importlib-metadata to v4.13.0 to avoid a problem in flake8.

Fixes #160.